### PR TITLE
feat: add explorer folder scoping mode

### DIFF
--- a/src/lib/app/action_registry/action_ids.ts
+++ b/src/lib/app/action_registry/action_ids.ts
@@ -73,6 +73,8 @@ export const ACTION_IDS = {
   filetree_skip_move_conflicts: "filetree.skip_move_conflicts",
   filetree_cancel_move_conflicts: "filetree.cancel_move_conflicts",
   filetree_toggle_star_selection: "filetree.toggle_star_selection",
+  filetree_scope_to_folder: "filetree.scope_to_folder",
+  filetree_clear_scope: "filetree.clear_scope",
 
   shell_open_url: "shell.open_url",
 

--- a/src/lib/app/bootstrap/ui/workspace_layout.svelte
+++ b/src/lib/app/bootstrap/ui/workspace_layout.svelte
@@ -13,7 +13,7 @@
   import { ContextRail } from "$lib/features/links";
   import { SvelteSet } from "svelte/reactivity";
   import { build_filetree, sort_tree } from "$lib/features/folder";
-  import { flatten_filetree } from "$lib/features/folder";
+  import { flatten_filetree, scope_flat_tree } from "$lib/features/folder";
   import { as_note_path } from "$lib/shared/types/ids";
   import { use_app_context } from "$lib/app/context/app_context.svelte";
   import { ACTION_IDS } from "$lib/app";
@@ -77,6 +77,18 @@
       pagination: stores.ui.filetree.pagination,
     }),
   );
+
+  const scoped_flat_nodes = $derived.by(() =>
+    scope_flat_tree(flat_nodes, stores.ui.filetree_scoped_root_path),
+  );
+
+  const scoped_root_folder_name = $derived.by(() => {
+    const scoped_root_path = stores.ui.filetree_scoped_root_path;
+    if (!scoped_root_path) {
+      return null;
+    }
+    return scoped_root_path.split("/").at(-1) ?? scoped_root_path;
+  });
 
   const starred_nodes = $derived.by(() => {
     const starred_paths = stores.notes.starred_paths;
@@ -440,6 +452,29 @@
                       {/each}
                     </div>
                   </div>
+                  {#if stores.ui.sidebar_view === "explorer" && stores.ui.filetree_scoped_root_path && scoped_root_folder_name}
+                    <div
+                      class="SidebarScope"
+                      title={stores.ui.filetree_scoped_root_path}
+                    >
+                      <span class="SidebarScope__label">Scoped to:</span>
+                      <span class="SidebarScope__value"
+                        >{scoped_root_folder_name}</span
+                      >
+                      <button
+                        type="button"
+                        class="SidebarScope__clear"
+                        onclick={() => {
+                          void action_registry.execute(
+                            ACTION_IDS.filetree_clear_scope,
+                          );
+                        }}
+                        aria-label="Clear file tree scope"
+                      >
+                        Clear
+                      </button>
+                    </div>
+                  {/if}
                 </Sidebar.Header>
 
                 <Sidebar.Content class="overflow-hidden">
@@ -555,7 +590,7 @@
                   >
                     <Sidebar.GroupContent class="h-full">
                       <VirtualFileTree
-                        nodes={flat_nodes}
+                        nodes={scoped_flat_nodes}
                         selected_path={stores.ui.selected_folder_path}
                         revealed_note_path={stores.ui
                           .filetree_revealed_note_path}
@@ -609,6 +644,16 @@
                           void action_registry.execute(
                             ACTION_IDS.folder_request_create,
                             folder_path,
+                          )}
+                        scoped_root_path={stores.ui.filetree_scoped_root_path}
+                        on_scope_to_folder={(folder_path: string) =>
+                          void action_registry.execute(
+                            ACTION_IDS.filetree_scope_to_folder,
+                            folder_path,
+                          )}
+                        on_clear_scope={() =>
+                          void action_registry.execute(
+                            ACTION_IDS.filetree_clear_scope,
                           )}
                         on_toggle_star={toggle_star_for_selection}
                         on_retry_load={(path: string) =>
@@ -753,6 +798,39 @@
     display: flex;
     flex-shrink: 0;
     align-items: center;
+  }
+
+  .SidebarScope {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-3);
+    border-block-end: 1px solid var(--border);
+    font-size: var(--text-xs);
+    color: var(--muted-foreground);
+  }
+
+  .SidebarScope__label {
+    flex-shrink: 0;
+  }
+
+  .SidebarScope__value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--foreground);
+    font-weight: 600;
+  }
+
+  .SidebarScope__clear {
+    margin-inline-start: auto;
+    color: var(--muted-foreground);
+    transition: color var(--duration-fast) var(--ease-default);
+  }
+
+  .SidebarScope__clear:hover {
+    color: var(--foreground);
   }
 
   :global(.SidebarHeaderButton) {

--- a/src/lib/app/orchestration/ui_store.svelte.ts
+++ b/src/lib/app/orchestration/ui_store.svelte.ts
@@ -285,6 +285,7 @@ export class UIStore {
     error_messages: SvelteMap<string, string>;
     pagination: SvelteMap<string, FolderPaginationState>;
   }>(initial_filetree());
+  filetree_scoped_root_path = $state<string | null>(null);
 
   image_paste_dialog = $state<{
     open: boolean;
@@ -422,6 +423,16 @@ export class UIStore {
     this.filetree_revealed_note_path = path;
   }
 
+  set_filetree_scoped_root_path(path: string | null) {
+    const normalized = path?.trim() ?? null;
+    this.filetree_scoped_root_path =
+      normalized && normalized.length > 0 ? normalized : null;
+  }
+
+  clear_filetree_scope() {
+    this.filetree_scoped_root_path = null;
+  }
+
   toggle_context_rail() {
     this.context_rail_open = !this.context_rail_open;
   }
@@ -466,6 +477,7 @@ export class UIStore {
     this.omnibar = { ...INITIAL_OMNIBAR };
     this.find_in_file = { ...INITIAL_FIND_IN_FILE };
     this.filetree = initial_filetree();
+    this.filetree_scoped_root_path = null;
     this.selected_items = new SvelteSet<string>();
     this.selection_anchor = null;
     this.image_paste_dialog = { ...INITIAL_IMAGE_PASTE_DIALOG };

--- a/src/lib/features/folder/application/filetree_action_helpers.ts
+++ b/src/lib/features/folder/application/filetree_action_helpers.ts
@@ -176,6 +176,15 @@ export function remap_ui_paths_after_move(
   new_path: string,
   is_folder: boolean,
 ) {
+  const scoped_root_path = input.stores.ui.filetree_scoped_root_path;
+  if (scoped_root_path) {
+    input.stores.ui.filetree_scoped_root_path = remap_path(
+      scoped_root_path,
+      old_path,
+      new_path,
+    );
+  }
+
   if (is_folder) {
     input.stores.ui.selected_folder_path = remap_path(
       input.stores.ui.selected_folder_path,
@@ -193,6 +202,22 @@ export function remap_ui_paths_after_move(
 
   if (input.stores.ui.filetree_revealed_note_path === old_path) {
     input.stores.ui.filetree_revealed_note_path = new_path;
+  }
+}
+
+export function clear_filetree_scope_if_removed(
+  input: ActionRegistrationInput,
+  removed_path: string,
+) {
+  const scoped_root_path = input.stores.ui.filetree_scoped_root_path;
+  if (!scoped_root_path) {
+    return;
+  }
+  if (
+    scoped_root_path === removed_path ||
+    scoped_root_path.startsWith(`${removed_path}/`)
+  ) {
+    input.stores.ui.filetree_scoped_root_path = null;
   }
 }
 

--- a/src/lib/features/folder/application/folder_actions.ts
+++ b/src/lib/features/folder/application/folder_actions.ts
@@ -2,10 +2,12 @@ import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import { ACTION_IDS } from "$lib/app/action_registry/action_ids";
 import type { ActionRegistrationInput } from "$lib/app/action_registry/action_registration_input";
 import {
+  clear_filetree_scope_if_removed,
   clear_folder_filetree_state,
   load_folder,
   remove_expanded_paths,
   remap_expanded_paths,
+  remap_path,
   remap_ui_paths_after_move,
   set_pagination,
   transform_filetree_paths,
@@ -255,6 +257,7 @@ export function register_folder_actions(input: ActionRegistrationInput) {
 
     close_delete_dialog(input);
     const parent_path = parent_folder_path(folder_path);
+    clear_filetree_scope_if_removed(input, folder_path);
     remove_expanded_paths(input, folder_path);
     clear_folder_filetree_state(input, parent_path);
 
@@ -306,6 +309,13 @@ export function register_folder_actions(input: ActionRegistrationInput) {
       stores.vault.bump_generation();
       services.folder.apply_folder_rename(folder_path, new_path);
       remap_expanded_paths(input, folder_path, new_path);
+      if (stores.ui.filetree_scoped_root_path) {
+        stores.ui.filetree_scoped_root_path = remap_path(
+          stores.ui.filetree_scoped_root_path,
+          folder_path,
+          new_path,
+        );
+      }
 
       clear_folder_filetree_state(input, folder_path);
       clear_folder_filetree_state(input, new_path);
@@ -405,6 +415,27 @@ export function register_folder_actions(input: ActionRegistrationInput) {
       label: "Clear File Tree Selection",
       execute: () => {
         stores.ui.clear_selected_items();
+      },
+    });
+
+    registry.register({
+      id: ACTION_IDS.filetree_scope_to_folder,
+      label: "Scope File Tree To Folder",
+      execute: (folder_path: unknown) => {
+        const path = String(folder_path).trim();
+        if (!path) {
+          return;
+        }
+        stores.ui.set_filetree_scoped_root_path(path);
+        stores.ui.set_sidebar_view("explorer");
+      },
+    });
+
+    registry.register({
+      id: ACTION_IDS.filetree_clear_scope,
+      label: "Clear File Tree Scope",
+      execute: () => {
+        stores.ui.clear_filetree_scope();
       },
     });
   }

--- a/src/lib/features/folder/domain/scope_flat_tree.ts
+++ b/src/lib/features/folder/domain/scope_flat_tree.ts
@@ -1,0 +1,40 @@
+import type { FlatTreeNode } from "$lib/shared/types/filetree";
+
+function is_scoped_descendant(path: string, scoped_root_path: string): boolean {
+  if (path === scoped_root_path) {
+    return true;
+  }
+  return path.startsWith(`${scoped_root_path}/`);
+}
+
+export function scope_flat_tree(
+  nodes: FlatTreeNode[],
+  scoped_root_path: string | null,
+): FlatTreeNode[] {
+  if (!scoped_root_path) {
+    return nodes;
+  }
+
+  const scoped_root_node = nodes.find(
+    (node) => !node.is_load_more && node.path === scoped_root_path,
+  );
+
+  if (!scoped_root_node) {
+    return [];
+  }
+
+  return nodes
+    .filter((node) => {
+      if (node.is_load_more) {
+        const parent = node.parent_path;
+        return !!parent && is_scoped_descendant(parent, scoped_root_path);
+      }
+      return is_scoped_descendant(node.path, scoped_root_path);
+    })
+    .map((node) => {
+      return {
+        ...node,
+        depth: Math.max(0, node.depth - scoped_root_node.depth),
+      };
+    });
+}

--- a/src/lib/features/folder/index.ts
+++ b/src/lib/features/folder/index.ts
@@ -9,6 +9,7 @@ export {
   move_destination_path,
 } from "$lib/features/folder/domain/filetree";
 export { flatten_filetree } from "$lib/features/folder/domain/flatten_filetree";
+export { scope_flat_tree } from "$lib/features/folder/domain/scope_flat_tree";
 export { default as CreateFolderDialog } from "$lib/features/folder/ui/create_folder_dialog.svelte";
 export { default as DeleteFolderDialog } from "$lib/features/folder/ui/delete_folder_dialog.svelte";
 export { default as RenameFolderDialog } from "$lib/features/folder/ui/rename_folder_dialog.svelte";

--- a/src/lib/features/folder/ui/file_tree_row.svelte
+++ b/src/lib/features/folder/ui/file_tree_row.svelte
@@ -16,6 +16,8 @@
     Star,
     StarOff,
     Copy,
+    Search,
+    X,
   } from "@lucide/svelte";
   import { toast } from "svelte-sonner";
 
@@ -56,6 +58,9 @@
     on_request_create_note?: (() => void) | undefined;
     on_request_create_folder?: ((folder_path: string) => void) | undefined;
     on_toggle_star?: ((path: string) => void) | undefined;
+    scoped_root_path?: string | null;
+    on_scope_to_folder?: ((folder_path: string) => void) | undefined;
+    on_clear_scope?: (() => void) | undefined;
     selection_count?: number;
     all_selected_starred?: boolean;
     on_retry_load: (path: string) => void;
@@ -87,6 +92,9 @@
     on_request_create_note,
     on_request_create_folder,
     on_toggle_star,
+    scoped_root_path = null,
+    on_scope_to_folder,
+    on_clear_scope,
     selection_count = 1,
     all_selected_starred = false,
     on_retry_load,
@@ -163,6 +171,8 @@
       on_select_folder(node.path);
     }
   }
+
+  const can_scope = $derived(!!on_scope_to_folder || !!on_clear_scope);
 </script>
 
 {#snippet row_content()}
@@ -310,6 +320,28 @@
               <span>Star</span>
             {/if}
           </ContextMenu.Item>
+          {#if can_scope}
+            <ContextMenu.Separator />
+            {#if scoped_root_path === node.path}
+              <ContextMenu.Item onSelect={() => on_clear_scope?.()}>
+                <X class="mr-2 h-4 w-4" />
+                <span>Clear Scope</span>
+              </ContextMenu.Item>
+            {:else}
+              <ContextMenu.Item
+                onSelect={() => on_scope_to_folder?.(node.path)}
+              >
+                <Search class="mr-2 h-4 w-4" />
+                <span>Scope to this</span>
+              </ContextMenu.Item>
+              {#if scoped_root_path}
+                <ContextMenu.Item onSelect={() => on_clear_scope?.()}>
+                  <X class="mr-2 h-4 w-4" />
+                  <span>Clear Scope</span>
+                </ContextMenu.Item>
+              {/if}
+            {/if}
+          {/if}
           {#if on_request_rename_folder || on_request_delete_folder}
             <ContextMenu.Separator />
             {#if on_request_rename_folder}

--- a/src/lib/features/folder/ui/virtual_file_tree.svelte
+++ b/src/lib/features/folder/ui/virtual_file_tree.svelte
@@ -33,6 +33,9 @@
     on_toggle_star?:
       | ((payload: { paths: string[]; all_starred: boolean }) => void)
       | undefined;
+    scoped_root_path?: string | null;
+    on_scope_to_folder?: ((folder_path: string) => void) | undefined;
+    on_clear_scope?: (() => void) | undefined;
     on_retry_load: (path: string) => void;
     on_load_more: (folder_path: string) => void;
     on_retry_load_more: (folder_path: string) => void;
@@ -62,6 +65,9 @@
     on_request_create_note,
     on_request_create_folder,
     on_toggle_star,
+    scoped_root_path = null,
+    on_scope_to_folder,
+    on_clear_scope,
     on_retry_load,
     on_load_more,
     on_retry_load_more,
@@ -412,6 +418,9 @@
             {on_request_create_note}
             {on_request_create_folder}
             on_toggle_star={on_toggle_star ? handle_toggle_star : undefined}
+            {scoped_root_path}
+            {on_scope_to_folder}
+            {on_clear_scope}
             selection_count={selected_items.length}
             {all_selected_starred}
             {on_retry_load}

--- a/tests/unit/actions/register_tab_actions.test.ts
+++ b/tests/unit/actions/register_tab_actions.test.ts
@@ -891,4 +891,68 @@ describe("register_tab_actions", () => {
       expect(stores.ui.filetree.expanded_paths.size).toBe(0);
     });
   });
+
+  describe("filetree scope", () => {
+    it("scopes explorer to a folder", async () => {
+      const { registry, stores } = create_tab_actions_harness();
+
+      await registry.execute(ACTION_IDS.filetree_scope_to_folder, "docs/specs");
+
+      expect(stores.ui.filetree_scoped_root_path).toBe("docs/specs");
+      expect(stores.ui.sidebar_view).toBe("explorer");
+    });
+
+    it("clears explorer scope", async () => {
+      const { registry, stores } = create_tab_actions_harness();
+      stores.ui.set_filetree_scoped_root_path("docs");
+
+      await registry.execute(ACTION_IDS.filetree_clear_scope);
+
+      expect(stores.ui.filetree_scoped_root_path).toBeNull();
+    });
+
+    it("remaps scope after folder rename", async () => {
+      const { registry, stores, services } = create_tab_actions_harness();
+      stores.ui.rename_folder_dialog = {
+        open: true,
+        folder_path: "docs",
+        new_name: "guides",
+      };
+      stores.ui.set_filetree_scoped_root_path("docs/specs");
+      (services.folder as Record<string, unknown>).rename_folder = vi
+        .fn()
+        .mockResolvedValue({ status: "success" });
+      (services.folder as Record<string, unknown>).apply_folder_rename =
+        vi.fn();
+      (services.folder as Record<string, unknown>).rename_folder_index = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await registry.execute(ACTION_IDS.folder_confirm_rename);
+
+      expect(stores.ui.filetree_scoped_root_path).toBe("guides/specs");
+    });
+
+    it("clears scope when scoped folder is deleted", async () => {
+      const { registry, stores, services } = create_tab_actions_harness();
+      stores.ui.delete_folder_dialog = {
+        open: true,
+        folder_path: "docs",
+        affected_note_count: 0,
+        affected_folder_count: 0,
+        status: "confirming",
+      };
+      stores.ui.set_filetree_scoped_root_path("docs/specs");
+      (services.folder as Record<string, unknown>).delete_folder = vi
+        .fn()
+        .mockResolvedValue({ status: "success" });
+      (services.folder as Record<string, unknown>).remove_notes_by_prefix = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await registry.execute(ACTION_IDS.folder_confirm_delete);
+
+      expect(stores.ui.filetree_scoped_root_path).toBeNull();
+    });
+  });
 });

--- a/tests/unit/domain/scope_flat_tree.test.ts
+++ b/tests/unit/domain/scope_flat_tree.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+import { scope_flat_tree } from "$lib/features/folder";
+import type { FlatTreeNode } from "$lib/shared/types/filetree";
+
+function folder_node(path: string, depth: number): FlatTreeNode {
+  return {
+    id: path,
+    path,
+    name: path.split("/").at(-1) ?? path,
+    depth,
+    is_folder: true,
+    is_expanded: false,
+    is_loading: false,
+    has_error: false,
+    error_message: null,
+    note: null,
+    parent_path: depth === 0 ? null : path.split("/").slice(0, -1).join("/"),
+    is_load_more: false,
+  };
+}
+
+function file_node(path: string, depth: number): FlatTreeNode {
+  return {
+    id: path,
+    path,
+    name: path.split("/").at(-1) ?? path,
+    depth,
+    is_folder: false,
+    is_expanded: false,
+    is_loading: false,
+    has_error: false,
+    error_message: null,
+    note: null,
+    parent_path: path.split("/").slice(0, -1).join("/"),
+    is_load_more: false,
+  };
+}
+
+function load_more_node(parent_path: string, depth: number): FlatTreeNode {
+  return {
+    id: `__load_more__${parent_path || "root"}`,
+    path: `__load_more__${parent_path || "root"}`,
+    name: "",
+    depth,
+    is_folder: false,
+    is_expanded: false,
+    is_loading: false,
+    has_error: false,
+    error_message: null,
+    note: null,
+    parent_path,
+    is_load_more: true,
+  };
+}
+
+describe("scope_flat_tree", () => {
+  test("returns all nodes when scope is null", () => {
+    const nodes = [folder_node("docs", 0), file_node("docs/note.md", 1)];
+    expect(scope_flat_tree(nodes, null)).toEqual(nodes);
+  });
+
+  test("keeps only scoped folder subtree and rebases depth", () => {
+    const nodes = [
+      folder_node("admin", 0),
+      folder_node("docs", 0),
+      folder_node("docs/specs", 1),
+      file_node("docs/specs/note.md", 2),
+      file_node("docs/readme.md", 1),
+      folder_node("public", 0),
+    ];
+
+    const result = scope_flat_tree(nodes, "docs");
+    expect(result.map((node) => node.path)).toEqual([
+      "docs",
+      "docs/specs",
+      "docs/specs/note.md",
+      "docs/readme.md",
+    ]);
+    expect(result.map((node) => node.depth)).toEqual([0, 1, 2, 1]);
+    expect(result[0]?.is_expanded).toBe(false);
+  });
+
+  test("keeps load-more rows for folders inside scope", () => {
+    const nodes = [
+      folder_node("docs", 0),
+      folder_node("docs/specs", 1),
+      load_more_node("docs/specs", 2),
+      folder_node("other", 0),
+      load_more_node("other", 1),
+    ];
+
+    const result = scope_flat_tree(nodes, "docs");
+    expect(result.map((node) => node.path)).toEqual([
+      "docs",
+      "docs/specs",
+      "__load_more__docs/specs",
+    ]);
+    expect(result.map((node) => node.depth)).toEqual([0, 1, 2]);
+  });
+
+  test("returns empty when scoped root folder is missing", () => {
+    const nodes = [folder_node("docs", 0), file_node("docs/readme.md", 1)];
+    expect(scope_flat_tree(nodes, "missing")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Explorer "Scope to this" and "Clear Scope" actions to isolate a folder subtree in the file tree
- add UI-scoped root state plus flat-tree scoping transform with depth rebasing while preserving canonical paths
- remap/clear scope on folder rename/delete, allow scoped-root collapse/expand, and add context-menu icons for scope actions

## Validation
- pnpm check
- pnpm lint
- pnpm test
- cargo check (src-tauri)
- pnpm format